### PR TITLE
Diff file is now only on the content

### DIFF
--- a/TCC.Lib/Dependencies/CompressionCommands.cs
+++ b/TCC.Lib/Dependencies/CompressionCommands.cs
@@ -41,7 +41,7 @@ namespace TCC.Lib.Dependencies
                 {
                     throw new Exception("todo ex msg");
                 }
-                cmd.Append($" -N \"{block.DiffDate.Value.ToLocalTime():yyyy-MM-dd HH:mm:ss}\"");
+                cmd.Append($" --newer-mtime \"{block.DiffDate.Value.ToLocalTime():yyyy-MM-dd HH:mm:ss}\"");
             }
 
             switch (option.PasswordOption.PasswordMode)


### PR DESCRIPTION
In some case, we backup each times files even if there contents have not changed. More information on : https://www.gnu.org/software/tar/manual/html_section/after.html


Note, for incrementing backup, we should used the option provided by tar : https://www.gnu.org/software/tar/manual/html_section/Incremental-Dumps.html#Incremental-Dumps