### PR TITLE
Fix du déchiffrement avec un mot de passe par fichier

### DIFF
--- a/TCC.Lib/Dependencies/CompressionCommands.cs
+++ b/TCC.Lib/Dependencies/CompressionCommands.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Text;
 using TCC.Lib.Blocks;
+using TCC.Lib.Helpers;
 using TCC.Lib.Options;
 
 namespace TCC.Lib.Dependencies
@@ -158,7 +159,7 @@ namespace TCC.Lib.Dependencies
                 {
                     throw new CommandLineException("Password file missing");
                 }
-                return "-kfile " + passwordFile.PasswordFile;
+                return "-kfile " + passwordFile.PasswordFile.Escape();
             }
             else
             {

--- a/TCC.Lib/Dependencies/CompressionCommands.cs
+++ b/TCC.Lib/Dependencies/CompressionCommands.cs
@@ -143,8 +143,7 @@ namespace TCC.Lib.Dependencies
 
         private static string PasswordCommand(TccOption option)
         {
-            if (option.PasswordOption.PasswordMode == PasswordMode.InlinePassword
-                && option.PasswordOption is InlinePasswordOption inlinePassword)
+            if (option.PasswordOption.PasswordMode == PasswordMode.InlinePassword && option.PasswordOption is InlinePasswordOption inlinePassword)
             {
                 if (string.IsNullOrWhiteSpace(inlinePassword.Password))
                 {
@@ -152,8 +151,8 @@ namespace TCC.Lib.Dependencies
                 }
                 return "-k " + inlinePassword.Password;
             }
-            else if (option.PasswordOption.PasswordMode == PasswordMode.PasswordFile
-                && option.PasswordOption is PasswordFileOption passwordFile)
+
+            if (option.PasswordOption.PasswordMode == PasswordMode.PasswordFile && option.PasswordOption is PasswordFileOption passwordFile)
             {
                 if (string.IsNullOrWhiteSpace(passwordFile.PasswordFile))
                 {
@@ -161,10 +160,9 @@ namespace TCC.Lib.Dependencies
                 }
                 return "-kfile " + passwordFile.PasswordFile.Escape();
             }
-            else
-            {
-                throw new NotSupportedException($"PasswordMode: {option.PasswordOption.PasswordMode} not supproted");
-            }
+
+            throw new NotSupportedException($"PasswordMode: {option.PasswordOption.PasswordMode} is not supported");
+
         }
     }
 }


### PR DESCRIPTION
# Fix du déchiffrement avec un mot de passe par fichier.

Lors de la phase de déchiffrement avec un mot de passe fourni par fichier, le mot de passe était stocké en mémoire dans les objets `Block`. Mais il n'était renseigné que pour le `Block` Full ou le premier `Block` Diff. Donc lors du déchiffrement, seul le premier block passait. Les autres échouaient.

On récupère maintenant le mot de passe par fichier dans les options `TccOption` pour déchiffrer (comme pour le mot de passe inline).